### PR TITLE
ci: Refine workflow trigger conditions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -6,11 +6,14 @@ on:
       - README.md
       - LICENSE.md
       - 'docs/**'
+    branches:
+      - root
   pull_request:
     paths-ignore:
       - README.md
       - LICENSE.md
       - 'docs/**'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This improvement simplifies pull requests so that only one workflow execution occurs for a pull request (making it so only one deployment approval is required). The ```workflow_dispatch``` trigger was added so that testing on a branch can be performed without opening a pull request.