### PR TITLE
ci: Update workflow syntax to fix dev env deployment

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -82,7 +82,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@ba1486788b0490a235422264426c45848eac35c6
         with:
           repository-name: jjliggett/CurrentTimeApp-dev-env
-          token: "${{ secrets.DEV_PAT_TOKEN }}"
+          token: ${{ secrets.DEV_PAT_TOKEN }}
           branch: gh-pages
           folder: release/wwwroot
           git-config-name: jjliggett


### PR DESCRIPTION
This is a workflow syntax update for the error discovered here: https://github.com/jjliggett/CurrentTimeApp/pull/67

Previously, the dev environment deployment was failing with the following error:

```
Checking if there are files to commit…
/usr/bin/git add --all .
/usr/bin/git checkout -b github-pages-deploy-action/laftxo8zq
Switched to a new branch 'github-pages-deploy-action/laftxo8zq'
/usr/bin/git commit -m Deploying to gh-pages from @ jjliggett/CurrentTimeApp@7a96b4233d[67](https://github.com/jjliggett/CurrentTimeApp/actions/runs/3457305907/jobs/5770658467#step:6:68)a43f840b142f8fb40c12dbe3dd17 🚀 --quiet --no-verify
Force-pushing changes...
/usr/bin/git push --force ***github.com/jjliggett/CurrentTimeApp-dev-env.git github-pages-deploy-action/laftxo8zq:gh-pages
remote: Invalid username or password.
fatal: Authentication failed for 'https://github.com/jjliggett/CurrentTimeApp-dev-env.git/'
Running post deployment cleanup jobs… 🗑️
/usr/bin/git checkout -B github-pages-deploy-action/laftxo8zq
Reset branch 'github-pages-deploy-action/laftxo8zq'
/usr/bin/chmod -R +rw github-pages-deploy-action-temp-deployment-folder
/usr/bin/git worktree remove github-pages-deploy-action-temp-deployment-folder --force
Error: The deploy step encountered an error: The process '/usr/bin/git' failed with exit code 128 ❌
Notice: Deployment failed! ❌
```

( https://github.com/jjliggett/CurrentTimeApp/actions/runs/3457305907/jobs/5770658467 - https://github.com/jjliggett/CurrentTimeApp/pull/69 )

This error appears to be from the token secret being within quotes. This previously worked, but it no longer works.

I tested this change in this PR with the manual workflow dispatch and it worked:

![image](https://user-images.githubusercontent.com/67353173/201554695-76f2e4d9-dd68-4084-a1c3-b0997d5c952b.png)

( https://github.com/jjliggett/CurrentTimeApp/actions/runs/3457663380 )