### PR TITLE
ci: Use personal access token for prod deployment

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -151,6 +151,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@ba1486788b0490a235422264426c45848eac35c6
         if: ${{ github.ref == 'refs/heads/root' }}
         with:
+          token: ${{ secrets.PROD_PAT_TOKEN }}
           branch: gh-pages
           folder: release/wwwroot
           git-config-name: jjliggett
@@ -195,7 +196,7 @@ jobs:
         uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
         if: ${{ github.ref == 'refs/heads/root' && env.VERSION != env.PREVIOUS_COMMIT_VERSION }}
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.PROD_PAT_TOKEN }}
           automatic_release_tag: v${{ env.VERSION }}
           prerelease: false
           files: |


### PR DESCRIPTION
This fixes this issue:

```
branch 'gh-pages' set up to track 'origin/gh-pages'.
/usr/bin/chmod -R +rw /home/runner/work/CurrentTimeApp/CurrentTimeApp/release/wwwroot
/usr/bin/rsync -q -av --checksum --progress /home/runner/work/CurrentTimeApp/CurrentTimeApp/release/wwwroot/. github-pages-deploy-action-temp-deployment-folder --delete --exclude CNAME --exclude .ssh --exclude .git --exclude .github
Checking if there are files to commit…
/usr/bin/git add --all .
/usr/bin/git checkout -b github-pages-deploy-action/duc8kgr2q
Switched to a new branch 'github-pages-deploy-action/duc8kgr2q'
/usr/bin/git commit -m Deploying to gh-pages from @ jjliggett/CurrentTimeApp@6f89441ac922f7fa476a86338b9d053cb1743a37 🚀 --quiet --no-verify
Force-pushing changes...
/usr/bin/git push --force ***github.com/jjliggett/CurrentTimeApp.git github-pages-deploy-action/duc8kgr2q:gh-pages
remote: Permission to jjliggett/CurrentTimeApp.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/jjliggett/CurrentTimeApp.git/': The requested URL returned error: 403
Running post deployment cleanup jobs… 🗑️
/usr/bin/git checkout -B github-pages-deploy-action/duc8kgr2q
Reset branch 'github-pages-deploy-action/duc8kgr2q'
/usr/bin/chmod -R +rw github-pages-deploy-action-temp-deployment-folder
/usr/bin/git worktree remove github-pages-deploy-action-temp-deployment-folder --force
Error: The deploy step encountered an error: The process '/usr/bin/git' failed with exit code 128 ❌
Notice: Deployment failed! ❌
```

https://github.com/jjliggett/CurrentTimeApp/actions/runs/4401119984/jobs/7707047387