### PR TITLE
feat: Set the header bar and address bar color for mobile devices

### DIFF
--- a/CurrentTimeApp/wwwroot/index.html
+++ b/CurrentTimeApp/wwwroot/index.html
@@ -9,6 +9,11 @@
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="CurrentTimeApp.styles.css" rel="stylesheet" />
+
+    <!-- Chrome, Firefox OS and Opera -->
+    <meta name="theme-color" content="#03173D">
+    <!-- Windows Phone -->
+    <meta name="msapplication-navbutton-color" content="#03173D">
 </head>
 
 <body>


### PR DESCRIPTION
This sets the color of the header bar and the address bar for mobile devices.

For context, see: https://stackoverflow.com/questions/26960703/how-can-i-change-the-color-of-header-bar-and-address-bar-in-the-newest-chrome-ve and https://developer.chrome.com/blog/support-for-theme-color-in-chrome-39-for-android/