### PR TITLE
fix: Fix daylight savings time logic

### DIFF
--- a/CurrentTimeApp.Components/CurrentTime.razor
+++ b/CurrentTimeApp.Components/CurrentTime.razor
@@ -55,23 +55,45 @@
     private class TimeZoneTime
     {
         public TimeZoneInfo TimeZone { get; set; }
-        public DateTime CurrentTime { get; set; }
-        public string TimeZoneName { get; set; }
+        public DateTime CurrentTimeUtc { get; set; }
+        public DateTime CurrentTime
+        {
+            get
+            {
+                return TimeZoneInfo.ConvertTimeBySystemTimeZoneId(CurrentTimeUtc, TimeZone.Id);
+            }
+        }
+        public string TimeZoneName
+        {
+            get
+            {
+                return IsDaylightSavingTime() ? TimeZone.DaylightName : TimeZone.StandardName;
+            }
+        }
         public bool DoesDstMessageExist { get; set; }
         public string DstMessage { get; set; }
 
         public TimeZoneTime(
             TimeZoneInfo timeZone,
-            DateTime currentTime,
-            string timeZoneName,
+            DateTime currentTimeUtc,
             bool doesDstMessageExist,
             string dstMessage)
         {
             TimeZone = timeZone ?? throw new ArgumentNullException(nameof(timeZone));
-            CurrentTime = currentTime;
-            TimeZoneName = timeZoneName ?? throw new ArgumentNullException(nameof(timeZoneName));
+            CurrentTimeUtc = currentTimeUtc;
+
+            if (currentTimeUtc.Kind != DateTimeKind.Utc)
+            {
+                throw new Exception("UTC time required to calculate time for time zone");
+            }
+
             DoesDstMessageExist = doesDstMessageExist;
             DstMessage = dstMessage ?? throw new ArgumentNullException(nameof(dstMessage));
+        }
+
+        public bool IsDaylightSavingTime()
+        {
+            return TimeZone.IsDaylightSavingTime(CurrentTimeUtc);
         }
     }
 
@@ -94,12 +116,9 @@
 
                     if (zone is not null)
                     {
-                        var time = TimeZoneInfo.ConvertTimeBySystemTimeZoneId(utcNow, tzs);
-
                         timeZoneTime.Add(new TimeZoneTime(
                             timeZone: zone,
-                            currentTime: time,
-                            timeZoneName: time.IsDaylightSavingTime() ? zone.DaylightName : zone.StandardName,
+                            currentTimeUtc: utcNow,
                             doesDstMessageExist: false,
                             dstMessage: ""
                         ));
@@ -128,6 +147,7 @@
             List<Task> tasks = new();
 
             currentTime = DateTime.Now;
+            timeZoneName = DateTime.Now.IsDaylightSavingTime() ? TimeZoneInfo.Local.DaylightName : TimeZoneInfo.Local.StandardName;
             utcNow = currentTime.ToUniversalTime();
 
             tasks.Add(Task.Run(action: () =>
@@ -145,14 +165,13 @@
             {
                 tasks.Add(Task.Run(action: () =>
                 {
-                    tzt.CurrentTime = TimeZoneInfo.ConvertTimeBySystemTimeZoneId(utcNow, tzt.TimeZone.Id);
-                    tzt.TimeZoneName = tzt.CurrentTime.IsDaylightSavingTime() ? tzt.TimeZone.DaylightName : tzt.TimeZone.StandardName;
+                    tzt.CurrentTimeUtc = utcNow;
 
                     var tztTransitionTime = getNextTransitionTime(tzt.TimeZone, tzt.CurrentTime);
 
                     if (tztTransitionTime is not null)
                     {
-                        tzt.DstMessage = $"DST will {(tzt.CurrentTime.IsDaylightSavingTime() ? "end" : "start")} on {tztTransitionTime:D} at {tztTransitionTime:t}.";
+                        tzt.DstMessage = $"DST will {(tzt.IsDaylightSavingTime() ? "end" : "start")} on {tztTransitionTime:D} at {tztTransitionTime:t}.";
                         tzt.DoesDstMessageExist = true;
                     }
                 }));


### PR DESCRIPTION
Previously, DST was calculated using the local time zone for all time zones. This was not correct. This commit changes the logic so that DST is correctly calculated based on the time zone and UTC time.

As we can see here in the photo on this PR - https://github.com/jjliggett/CurrentTimeApp/pull/123 , the time zone for Phoenix, Arizona incorrectly displayed MDT despite the fact that daylight savings time is not observed throughout the majority of Arizona. Getting whether daylight savings time is in effect using the `TimeZoneInfo` and utc time fixes that issue. This also resolves issues with the next DST change message as well.

As we can see below, this change corrects that issue. There is correct information for Phoenix, Arizona and Auckland in New Zealand:

![image](https://user-images.githubusercontent.com/67353173/236717847-6edbb8cf-f7a3-4aa5-831b-b354933b02da.png)

![image](https://user-images.githubusercontent.com/67353173/236718368-5c9a87cb-1469-46bb-bb15-1dcfdb6d432d.png)

( https://www.govt.nz/browse/recreation-and-the-environment/daylight-saving/ )