### PR TITLE
ci(deps): Update artifact actions to new major versions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -55,7 +55,7 @@ jobs:
         run: touch release/wwwroot/.nojekyll
       - run: cp release/wwwroot/index.html release/wwwroot/404.html
       - name: Upload release.zip
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: release
           path: release/
@@ -99,7 +99,7 @@ jobs:
         run: dotnet publish --no-restore -c Release -o android-release -f net7.0-android CurrentTimeApp.MauiBlazor/CurrentTimeApp.MauiBlazor.csproj
       - run: ls -R
       - name: Upload release.zip
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: android-release
           path: android-release/
@@ -117,7 +117,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download build
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.
         with:
           name: release
           path: release/
@@ -144,7 +144,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download build
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.
         with:
           name: release
           path: release/
@@ -189,7 +189,7 @@ jobs:
       - run: echo "VERSION=$(echo ${{ steps.jjversion.outputs.majorMinorPatch }})" >> $GITHUB_ENV
       - run: echo "PREVIOUS_COMMIT_VERSION=$(echo ${{ steps.previousversion.outputs.majorMinorPatch }})" >> $GITHUB_ENV
       - name: Download build
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.
         with:
           name: android-release
           path: android-release/


### PR DESCRIPTION
This is a major upgrade for the artifacts architecture.

This closes #182 and it closes #183.

This is similar to:

- https://github.com/jjliggett/jjversion/pull/307
- https://github.com/jjliggett/jjversion-gha-output/pull/95
